### PR TITLE
fix: 40 tile now working as expected, indexed updated

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/model/board/TileFactory.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/model/board/TileFactory.java
@@ -30,6 +30,13 @@ public class TileFactory {
                 }
             }
         }
+
+        for (Tile tile : tiles) {
+            // print tile pos and type and title
+            System.out.println("Tile: " + tile.getIndex() + " " + tile.getType() + " " + (tile instanceof StreetTile ? ((StreetTile) tile).getLabel() : ""));
+
+        }
+
         return tiles;
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/model/gamestate/Player.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/model/gamestate/Player.java
@@ -143,7 +143,7 @@ public class Player implements Comparable<Player> {
 
     public void moveToTile(int index) {
         if (!isSuspended()) {
-            Tile destination = board.getTile(index % board.getTiles().size());
+            Tile destination = board.getTile(index);
             this.currentTile = destination;
         }
     }
@@ -151,11 +151,21 @@ public class Player implements Comparable<Player> {
     public void moveSteps(int steps) {
         System.out.println("Moving " + steps + " steps from " + currentTile);
         if (!isSuspended()) {
-            int currentIndex = (currentTile != null) ? currentTile.getIndex() : -1;
-            int totalTiles = board.getTiles().size();
-            int newIndex = (currentIndex + steps) % totalTiles;
+            int currentIndex = (currentTile != null)
+                    ? currentTile.getIndex()
+                    : 1;            // or whatever your “start” tile is
+
+            int totalTiles   = board.getTiles().size();  // 40
+            // step 1: shift into 0-based by subtracting 1
+            int zeroBased    = currentIndex - 1;
+            // step 2: add steps and wrap around with % totalTiles
+            int wrapped      = (zeroBased + steps) % totalTiles;
+            // step 3: shift back into 1-based by adding 1
+            int newIndex     = wrapped + 1;
+
             moveToTile(newIndex);
-            setHasRolledDice(true);
+
+            System.out.println("Now on tile: " + newIndex);
         }
     }
 

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/game_request/RollDiceRequest.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/game_request/RollDiceRequest.java
@@ -53,7 +53,8 @@ public class RollDiceRequest implements GameRequest {
 
             // get current tile
             Tile currentTile = player.getCurrentTile();
-            System.out.println("Player " + player.getNickname() + " is on tile: " + (currentTile != null ? currentTile.getType() : "null"));
+            // print name of street if street
+            System.out.println("Player " + player.getNickname() + " is on tile: " + currentTile.getIndex() + " " + currentTile.getType() + " " + (currentTile instanceof StreetTile ? ((StreetTile) currentTile).getLabel() : ""));
 
             if (player.isSuspended()) {
                 System.out.println("Player " + player.getNickname() + " is suspended for " + player.getSuspensionRounds() + " rounds.");


### PR DESCRIPTION
### Tile Movement Refactor:
* **Refactored `moveSteps` Method**: Simplified the tile movement logic in `Player.moveSteps()` by shifting to a 1-based index system for clarity, with explicit steps for zero-based conversion, wrapping, and shifting back to 1-based indexing. Added logging to indicate the new tile after movement.

* **Fixed Tile Indexing in `moveToTile`**: Removed the modulo operation in `Player.moveToTile()` to directly use the provided tile index, ensuring correctness when accessing tiles. 