### PR TITLE
feat: add Rolling out of Prison

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/dto/MessageType.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dto/MessageType.java
@@ -6,6 +6,9 @@ public enum MessageType {
     ASK_BUY_PROPERTY,
     ASK_PAY_PRISON,
     PAY_PRISON,
+    ROLL_PRISON,
+    ROLLED_PRISON,
+
     BUY_PROPERTY,
     GO_TO_JAIL,
     PAY_RENT,

--- a/src/main/java/at/aau/serg/websocketdemoserver/model/gamestate/GameState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/model/gamestate/GameState.java
@@ -95,6 +95,11 @@ public class GameState {
                 return;
             }
 
+            if (!current.isAlive()) {
+                // set money to -1
+                current.setCash(-1);
+            }
+
             loopCounter++;
         } while (loopCounter < turnOrder.size());
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/GameHandler.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/GameHandler.java
@@ -31,6 +31,7 @@ public class GameHandler {
         requestMap.put(ROLL_DICE, new RollDiceRequest(new Dice(1,6)));
         requestMap.put(BUY_PROPERTY, new BuyPropertyRequest());
         requestMap.put(PAY_PRISON, new PayPrisonRequest());
+        requestMap.put(ROLL_PRISON, new RollPrisonRequest(new Dice(1,6)));
         requestMap.put(DRAW_BANK_CARD, new DrawBankCardRequest(BankCardDeck.get()));
         requestMap.put(DRAW_RISK_CARD, new DrawRiskCardRequest(RiskCardDeck.get(), jailTile));
         requestMap.put(PAY_TAX, new PayTaxRequest());

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/game_request/RollPrisonRequest.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/game_request/RollPrisonRequest.java
@@ -1,0 +1,73 @@
+package at.aau.serg.websocketdemoserver.service.game_request;
+
+import at.aau.serg.websocketdemoserver.dto.GameMessage;
+import at.aau.serg.websocketdemoserver.dto.MessageType;
+import at.aau.serg.websocketdemoserver.dto.RiskCardDrawnPayload;
+import at.aau.serg.websocketdemoserver.dto.WentToJailPayload;
+import at.aau.serg.websocketdemoserver.model.board.StreetTile;
+import at.aau.serg.websocketdemoserver.model.board.Tile;
+import at.aau.serg.websocketdemoserver.model.gamestate.GameState;
+import at.aau.serg.websocketdemoserver.model.gamestate.Player;
+import at.aau.serg.websocketdemoserver.model.util.Dice;
+import at.aau.serg.websocketdemoserver.service.GameRequest;
+import at.aau.serg.websocketdemoserver.service.MessageFactory;
+import org.json.JSONObject;
+
+import java.util.List;
+import java.util.Map;
+
+public class RollPrisonRequest implements GameRequest {
+
+    private final Dice dice;
+
+    public RollPrisonRequest(Dice dice) {
+        this.dice = dice;
+    }
+
+    @Override
+    public GameMessage execute(int lobbyId, Object payload, GameState gameState, List<GameMessage> extraMessages) {
+        try {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) payload;
+            JSONObject obj = new JSONObject(map);
+
+            int playerId = obj.getInt("playerId");
+            Player player = gameState.getPlayer(playerId);
+
+            if (player == null || !player.isAlive()) {
+                return MessageFactory.error(lobbyId, "Spieler ungültig oder bereits ausgeschieden.");
+            }
+
+            int roll1 = dice.roll();
+            int roll2 = dice.roll();
+
+            System.out.println("Prison roll: " + player.getNickname() + " rolled " + roll1 + " and " + roll2);
+
+            if (roll1 == roll2) {
+                player.setSuspensionRounds(0);
+                player.setHasEscapeCard(false);
+                extraMessages.add(new GameMessage(
+                        lobbyId,
+                        MessageType.ROLLED_PRISON,
+                        new JSONObject().put("playerId", playerId).put("roll1", roll1).put("roll2", roll2).toMap()
+                ));
+            } else {
+                extraMessages.add(new GameMessage(
+                        lobbyId,
+                        MessageType.ROLLED_PRISON,
+                        new JSONObject().put("playerId", playerId).put("roll1", roll1).put("roll2", roll2).toMap()
+                ));
+            }
+
+
+            gameState.advanceTurn();
+            return MessageFactory.gameState(lobbyId, gameState);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return MessageFactory.error(lobbyId, "Fehler beim Würfeln im Gefängnis: " + e.getMessage());
+        }
+
+    }
+
+}


### PR DESCRIPTION
This pull request introduces functionality for handling dice rolls while a player is in prison, along with related updates to the game state and messaging system. Key changes include the addition of a new `RollPrisonRequest` class, updates to the `MessageType` enum, and enhancements to game state handling for eliminated players.

### New functionality for prison dice rolls:
* Added a new `RollPrisonRequest` class to handle dice rolls for players in prison. This includes logic for checking if a player rolls doubles to escape prison and sending appropriate game messages (`ROLLED_PRISON`) with roll results. 
* Updated the `MessageType` enum to include `ROLL_PRISON` and `ROLLED_PRISON` message types to support the new prison roll functionality.
* Registered the `ROLL_PRISON` request in the `GameHandler` to integrate it into the game's request handling system. 

### Game state enhancements:
* Modified the `advanceTurn` method in `GameState` to set a player's cash to `-1` if they are no longer alive, ensuring proper handling of eliminated players.