### PR TITLE
Add LobbySubscriptionListener to handle lobby updates on subscription

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/WebSocketDemoServerApplication.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/WebSocketDemoServerApplication.java
@@ -2,10 +2,11 @@ package at.aau.serg.websocketdemoserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class WebSocketDemoServerApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(WebSocketDemoServerApplication.class, args);
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/controller/LobbyWebSocketController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/controller/LobbyWebSocketController.java
@@ -43,25 +43,4 @@ public class LobbyWebSocketController {
                 messagingTemplate.convertAndSend("/topic/lobby", resp)
         );
     }
-
-    /**
-     * Handles JOIN_LOBBY and START_GAME for a specific lobby.
-     * Clients send to /app/lobby/{lobbyId}, subscribe to /topic/lobby/{lobbyId}.
-     */
-    @MessageMapping("/lobby/{lobbyId}")
-    public void handleByLobby(@DestinationVariable int lobbyId,
-                              @Payload LobbyMessage message) {
-        logger.info("Lobby {}: {}", lobbyId, message.getType());
-        message.setLobbyId(lobbyId);
-        List<LobbyMessage> responses = lobbyService.handle(message);
-        for (var resp : responses) {
-            if (resp.getType() == LobbyMessageType.LOBBY_LIST) {
-                // still broadcast lobby list globally
-                messagingTemplate.convertAndSend("/topic/lobby", resp);
-            } else {
-                // per‐lobby updates
-                messagingTemplate.convertAndSend("/topic/lobby/" + lobbyId, resp);
-            }
-        }
-    }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/GameHandler.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/GameHandler.java
@@ -11,6 +11,7 @@ import at.aau.serg.websocketdemoserver.model.gamestate.Player;
 import at.aau.serg.websocketdemoserver.model.util.Dice;
 import at.aau.serg.websocketdemoserver.model.util.DicePair;
 import at.aau.serg.websocketdemoserver.service.game_request.*;
+import lombok.Getter;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -20,6 +21,7 @@ import static at.aau.serg.websocketdemoserver.dto.MessageType.*;
 @Service
 public class GameHandler {
 
+    @Getter
     private final GameState gameState;
     private final Map<MessageType, GameRequest> requestMap = new HashMap<>();
     private final List<GameMessage> extraMessages = new ArrayList<>();

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/GameManager.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/GameManager.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public class GameManager {
     @Getter
     private static final GameManager instance = new GameManager();
+    @Getter
     private final Map<Integer, GameHandler> handlers = new HashMap<>();
 
     private GameManager() {}

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/GameStateBroadcaster.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/GameStateBroadcaster.java
@@ -25,7 +25,7 @@ public class GameStateBroadcaster {
         this.messagingTemplate = messagingTemplate;
     }
 
-    @Scheduled(fixedRate = 1000)
+    @Scheduled(fixedRate = 2000)
     public void broadcastGameStates() {
         Map<Integer, GameHandler> handlers = GameManager.getInstance().getHandlers();
         for (Map.Entry<Integer, GameHandler> entry : handlers.entrySet()) {
@@ -35,7 +35,7 @@ public class GameStateBroadcaster {
             if (gameState != null) {
                 GameMessage gameStateMsg = MessageFactory.gameState(lobbyId, gameState);
                 messagingTemplate.convertAndSend("/topic/dkt/" + lobbyId, gameStateMsg);
-                logger.info("Broadcasted game state to lobby {}", lobbyId);
+                logger.debug("Broadcasted game state to lobby {}", lobbyId);
             }
         }
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/GameStateBroadcaster.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/GameStateBroadcaster.java
@@ -1,0 +1,44 @@
+package at.aau.serg.websocketdemoserver.service;
+
+import at.aau.serg.websocketdemoserver.dto.GameMessage;
+import at.aau.serg.websocketdemoserver.dto.MessageType;
+import at.aau.serg.websocketdemoserver.model.gamestate.GameState;
+import at.aau.serg.websocketdemoserver.service.GameHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class GameStateBroadcaster {
+    private static final Logger logger = LoggerFactory.getLogger(GameStateBroadcaster.class);
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final GameManager gameManager;
+
+    @Autowired
+    public GameStateBroadcaster(SimpMessagingTemplate messagingTemplate, GameManager gameManager) {
+        this.messagingTemplate = messagingTemplate;
+        this.gameManager = gameManager;
+    }
+
+    @Scheduled(fixedRate = 1000)
+    public void broadcastGameStates() {
+        Map<Integer, GameHandler> handlers = gameManager.getHandlers();
+        for (Map.Entry<Integer, GameHandler> entry : handlers.entrySet()) {
+            int lobbyId = entry.getKey();
+            GameHandler handler = entry.getValue();
+            GameState gameState = handler.getGameState();
+            if (gameState != null) {
+                GameMessage gameStateMsg = new GameMessage(lobbyId, MessageType.GAME_STATE, gameState);
+                messagingTemplate.convertAndSend("/topic/dkt/" + lobbyId, gameStateMsg);
+                logger.debug("Broadcasted game state to lobby {}", lobbyId);
+            }
+        }
+    }
+}
+

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/GameStateBroadcaster.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/GameStateBroadcaster.java
@@ -4,6 +4,7 @@ import at.aau.serg.websocketdemoserver.dto.GameMessage;
 import at.aau.serg.websocketdemoserver.dto.MessageType;
 import at.aau.serg.websocketdemoserver.model.gamestate.GameState;
 import at.aau.serg.websocketdemoserver.service.GameHandler;
+import at.aau.serg.websocketdemoserver.service.MessageFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,27 +19,24 @@ public class GameStateBroadcaster {
     private static final Logger logger = LoggerFactory.getLogger(GameStateBroadcaster.class);
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final GameManager gameManager;
 
     @Autowired
-    public GameStateBroadcaster(SimpMessagingTemplate messagingTemplate, GameManager gameManager) {
+    public GameStateBroadcaster(SimpMessagingTemplate messagingTemplate) {
         this.messagingTemplate = messagingTemplate;
-        this.gameManager = gameManager;
     }
 
     @Scheduled(fixedRate = 1000)
     public void broadcastGameStates() {
-        Map<Integer, GameHandler> handlers = gameManager.getHandlers();
+        Map<Integer, GameHandler> handlers = GameManager.getInstance().getHandlers();
         for (Map.Entry<Integer, GameHandler> entry : handlers.entrySet()) {
             int lobbyId = entry.getKey();
             GameHandler handler = entry.getValue();
             GameState gameState = handler.getGameState();
             if (gameState != null) {
-                GameMessage gameStateMsg = new GameMessage(lobbyId, MessageType.GAME_STATE, gameState);
+                GameMessage gameStateMsg = MessageFactory.gameState(lobbyId, gameState);
                 messagingTemplate.convertAndSend("/topic/dkt/" + lobbyId, gameStateMsg);
-                logger.debug("Broadcasted game state to lobby {}", lobbyId);
+                logger.info("Broadcasted game state to lobby {}", lobbyId);
             }
         }
     }
 }
-

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/LobbyService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/LobbyService.java
@@ -3,6 +3,7 @@ package at.aau.serg.websocketdemoserver.service;
 import at.aau.serg.websocketdemoserver.dto.*;
 import at.aau.serg.websocketdemoserver.service.lobby_request.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 @Service
 public class LobbyService {
 
+    @Getter
     private final LobbyManager lobbyManager = new LobbyManager();
     private final UserManager userManager = new UserManager();
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/LobbySubscriptionListener.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/LobbySubscriptionListener.java
@@ -1,0 +1,71 @@
+package at.aau.serg.websocketdemoserver.websocket;
+
+import at.aau.serg.websocketdemoserver.dto.LobbyMessage;
+import at.aau.serg.websocketdemoserver.dto.LobbyMessageType;
+import at.aau.serg.websocketdemoserver.dto.LobbyUpdatePayload;
+import at.aau.serg.websocketdemoserver.service.LobbyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriTemplate;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import java.util.List;
+
+@Component
+public class LobbySubscriptionListener implements ApplicationListener<SessionSubscribeEvent> {
+    private static final Logger logger = LoggerFactory.getLogger(LobbySubscriptionListener.class);
+    private static final String LOBBY_GENERAL_TOPIC = "/topic/lobby";
+
+    @Autowired
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Autowired
+    private LobbyService lobbyService;
+
+    @Override
+    public void onApplicationEvent(SessionSubscribeEvent event) {
+        StompHeaderAccessor sha = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = sha.getDestination();
+        if (destination == null) return;
+        if (destination.equals(LOBBY_GENERAL_TOPIC)) {
+            try {
+                // Send LIST_LOBBIES message
+                LobbyMessage listLobbiesRequest = new LobbyMessage(LobbyMessageType.LIST_LOBBIES, null);
+                List<LobbyMessage> responses = lobbyService.handle(listLobbiesRequest);
+                for (LobbyMessage resp : responses) {
+                    messagingTemplate.convertAndSend(LOBBY_GENERAL_TOPIC, resp);
+                    logger.debug("Sent list message to {}: {}", LOBBY_GENERAL_TOPIC, resp);
+                }
+                // Send LOBBY_UPDATE for each lobby
+                // We assume the lobby list is in the payload of a LOBBY_LIST message
+                for (LobbyMessage resp : responses) {
+                    if (resp.getType() == LobbyMessageType.LOBBY_LIST && resp.getPayload() instanceof List) {
+                        List<?> lobbyList = (List<?>) resp.getPayload();
+                        for (Object lobbyObj : lobbyList) {
+                            logger.debug("Processing lobby object: {}", lobbyObj);
+                            if (lobbyObj instanceof java.util.Map map && map.containsKey("lobbyId")) {
+                                int lobbyId = (int) map.get("lobbyId");
+                                // Fetch the lobby's players for the update payload
+                                var lobby = lobbyService.getLobbyManager().getLobby(lobbyId);
+                                if (lobby != null) {
+                                    LobbyMessage updateMsg = new LobbyMessage(lobbyId, LobbyMessageType.LOBBY_UPDATE,
+                                        new LobbyUpdatePayload(lobbyId, lobby.getPlayers()));
+                                    messagingTemplate.convertAndSend(LOBBY_GENERAL_TOPIC, updateMsg);
+                                    logger.debug("Sent lobby update message to {}: {}", LOBBY_GENERAL_TOPIC, updateMsg);
+                                }
+                            }
+                        }
+                    }
+                }
+                logger.info("Sent LIST_LOBBIES and LOBBY_UPDATEs to {} on subscribe", LOBBY_GENERAL_TOPIC);
+            } catch (Exception e) {
+                logger.warn("Failed to send LIST_LOBBIES/LOBBY_UPDATE on subscribe: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/controller/LobbyWebSocketControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/controller/LobbyWebSocketControllerTest.java
@@ -45,23 +45,4 @@ class LobbyWebSocketControllerTest {
         verify(messagingTemplate).convertAndSend("/topic/lobby", response1);
         verify(messagingTemplate).convertAndSend("/topic/lobby", response2);
     }
-
-    @Test
-    void handleByLobby_sendsLobbyListGlobally_andOthersToLobbyTopic() {
-        // Arrange
-        int lobbyId = 42;
-        LobbyMessage input = new LobbyMessage(LobbyMessageType.JOIN_LOBBY, "Join");
-        LobbyMessage lobbyList = new LobbyMessage(LobbyMessageType.LOBBY_LIST, "List");
-        LobbyMessage lobbyUpdate = new LobbyMessage(lobbyId, LobbyMessageType.LOBBY_UPDATE, "Update");
-
-        when(lobbyService.handle(input)).thenReturn(List.of(lobbyList, lobbyUpdate));
-
-        // Act
-        controller.handleByLobby(lobbyId, input);
-
-        // Assert
-        verify(lobbyService).handle(input);
-        verify(messagingTemplate).convertAndSend("/topic/lobby", lobbyList);
-        verify(messagingTemplate).convertAndSend("/topic/lobby/" + lobbyId, lobbyUpdate);
-    }
 }


### PR DESCRIPTION
This pull request introduces a new `LobbySubscriptionListener` class to handle WebSocket subscription events and updates the `LobbyService` class to enhance accessibility of its `LobbyManager` instance. These changes improve the handling of lobby-related events and streamline access to lobby management functionality.

### New WebSocket Event Handling
Added a new class, `LobbySubscriptionListener`, to listen for WebSocket subscription events on the `/topic/lobby` destination. It sends `LIST_LOBBIES` and `LOBBY_UPDATE` messages to subscribers, ensuring real-time updates about lobby states.
